### PR TITLE
Ports TG's holywater effects

### DIFF
--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -83,6 +83,7 @@ h1.alert, h2.alert		{color: #000000;}
 .notice					{color: #000099;}
 .alium					{color: #00ff00;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
+.cultlarge				{color: #960000; font-weight: bold; font-size: 3;}	/* AEIOU change - TG holy water effects port */
 
 .reflex_shoot			{color: #000099; font-style: italic;}
 

--- a/modular_aeiou/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/modular_aeiou/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -1,0 +1,39 @@
+//HOLY WATER EFFECTS OVERRIDE - a port of TG's holy water effects
+
+/datum/reagent/water/holywater/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)	//Overrides default 10% chance of deconversion on ingestion with default chem behaviour
+	M.bloodstr.add_reagent(id, removed)
+	return
+
+/datum/reagent/water/holywater/on_mob_life(mob/living/M)
+	if(!data)
+		data = 1
+	data++
+	M.jitteriness = min(M.jitteriness+25,100)
+/*	if(M.mind && cult.is_antagonist(M.mind))	//Innate spells that cultists get on TG get disabled, but they don't exist on baycode
+		for(var/datum/action/innate/cult/blood_magic/BM in M.actions)
+			to_chat(M, "<span class='cultlarge'>Your blood rites falter as holy water scours your body!</span>")
+			for(var/datum/action/innate/cult/blood_spell/BS in BM.spells)
+				qdel(BS)	*/
+	if(data >= 25)		// 10 units, 45 seconds @ metabolism 0.4 units & tick rate 1.8 sec
+		if(!M.stuttering)
+			M.stuttering = 1
+		M.stuttering = min(M.stuttering+4, 10)
+		M.make_dizzy(25)
+		if(M.mind && cult.is_antagonist(M.mind) && prob(20))
+			M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"))
+			if(prob(20))
+				M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
+				M.Paralyse(15)
+				to_chat(M, "<span class='cultlarge'>[pick("Your blood is your bond - you are nothing without it.", "Do not forget your place.", "All that power and you still fail?")]</span>")
+			else
+				M.visible_message("<span class='warning'>[M] [pick("whimpers quietly", "shivers as though cold", "glances around in paranoia")].</span>")
+	if(data >= 60)	// 30 units, 135 seconds
+		if(M.mind && cult.is_antagonist(M.mind))
+			cult.remove_antagonist(M.mind)
+			M.jitteriness = 0
+			M.stuttering = 0
+			M.dizziness = 0
+			M.SetParalysis(0)
+			holder.remove_reagent(id, volume)	// maybe this is a little too perfect and a max() cap on the statuses would be better??
+			return
+	holder.remove_reagent(id, 0.4) //fixed consumption to prevent balancing going out of whack

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2892,4 +2892,5 @@
 #include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 #include "modular_aeiou\code\modules\client\preference_setup\loadout\loadout_head.dm"
+#include "modular_aeiou\code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Other.dm"
 // END_INCLUDE


### PR DESCRIPTION
:cl: Toriate
add: Holy water now has TG-style effects, taking approximately 45 seconds to take effect, and needing a total of about 135 seconds to deconvert cultists
/:cl:

This PR will port TG's holy water effects over. This means that it takes 45 seconds for 10u of holy water to take effect, but ultimately requires 30u of holy water and 135 seconds for a proper deconversion.

As the holy water takes effect, cultists will start stuttering, screaming, and even suffer from seizures. All negative effects are cleared after they are deconverted.

It is possible to remove holy water from someone before they get fully deconverted, however I have not coded in any special interactions for cultist tomes/blades to instantly purge their system of holy water.

Note that the times previously mentioned actually depend on the server's tickrate, and are based off a rate of 20 ticks/second. They absolutely can and will vary in the actual game.