### PR TITLE
Re-enables simple animal damage bonus

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -601,7 +601,7 @@
 	ai_log("bullet_act() I was shot by: [Proj.firer]",2)
 
 	/* VOREStation Edit - Ace doesn't like bonus SA damage. */
-	//AEIOU Edit: WELL I DO. ^Spitzer
+	//AEIOU Edit: WELL, I DO. ^Spitzer
 	//Projectiles with bonus SA damage
 	if(!Proj.nodamage)
 		if(!Proj.SA_vulnerability || Proj.SA_vulnerability == intelligence_level)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -600,12 +600,13 @@
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	ai_log("bullet_act() I was shot by: [Proj.firer]",2)
 
-	/* VOREStation Edit - Ace doesn't like bonus SA damage.
+	/* VOREStation Edit - Ace doesn't like bonus SA damage. */
+	//AEIOU Edit: WELL I DO. ^Spitzer
 	//Projectiles with bonus SA damage
 	if(!Proj.nodamage)
 		if(!Proj.SA_vulnerability || Proj.SA_vulnerability == intelligence_level)
 			Proj.damage += Proj.SA_bonus_damage
-	*/ // VOREStation Edit End
+	// VOREStation Edit End
 	. = ..()
 
 	if(Proj.firer)


### PR DESCRIPTION
:cl: EvilJackCarver
rsctweak: Re-enables simple animal bonus damage.
/:cl:

Re-enables bonus simpleanimal damage. Pretty much what it says on the tin.

We're aware the map test is failing; as long as the unit test passes we're good.