### PR TITLE
Adds air rifle to the cargo list

### DIFF
--- a/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
+++ b/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
@@ -1,0 +1,22 @@
+/datum/supply_packs/recreation/air_rifle
+	name = "Air Rifle Crate"
+	contains = list(
+			/obj/random/projectile/shotgun/airrifle = 2,
+			/obj/item/ammo_magazine/s177bb = 1
+			)
+	cost = 25
+	containertype = /obj/structure/closet/crate
+	containername = "air rifle crate"
+
+
+//random air rifle, used above.
+/obj/random/projectile/shotgun/airrifle
+	name = "Random Air Rifle"
+	desc = "This is a random air rifle, for PoIs/cargo."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "shotgun"
+
+/obj/random/projectile/shotgun/airrifle/item_to_spawn()
+	return pick(prob(20);/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle,		//weighted 20-to-1
+				prob(1);/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le
+				)

--- a/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
+++ b/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
@@ -18,5 +18,4 @@
 
 /obj/random/projectile/shotgun/airrifle/item_to_spawn()
 	return pick(prob(20);/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle,		//weighted 20-to-1
-				prob(1);/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le
-				)
+			prob(1);/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le)

--- a/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
+++ b/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
@@ -9,7 +9,7 @@
 	containername = "air rifle crate"
 
 
-//random air rifle, used above.	
+//random air rifle, used above.
 /obj/random/projectile/shotgun/airrifle
 	name = "Random Air Rifle"
 	desc = "This is a random air rifle, for PoIs/cargo."

--- a/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
+++ b/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
@@ -1,4 +1,4 @@
-/datum/supply_packs/recreation/air_rifle
+/datum/supply_packs/recreation/air_rifle	//Crate of two air rifles, and a tube of BBs
 	name = "Air Rifle Crate"
 	contains = list(
 			/obj/random/projectile/shotgun/airrifle = 2,

--- a/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
+++ b/modular_aeiou/code/datums/supplypacks/recreation_aeiou.dm
@@ -9,7 +9,7 @@
 	containername = "air rifle crate"
 
 
-//random air rifle, used above.
+//random air rifle, used above.	
 /obj/random/projectile/shotgun/airrifle
 	name = "Random Air Rifle"
 	desc = "This is a random air rifle, for PoIs/cargo."

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2959,6 +2959,7 @@
 #include "maps\tether\tether.dm"
 #include "maps\tether\submaps\_tether_submaps.dm"
 #include "maps\~map_system\maps.dm"
+#include "modular_aeiou\code\datums\supplypacks\recreation_aeiou.dm"
 #include "modular_aeiou\code\game\machinery\vending_aeiou.dm"
 #include "modular_aeiou\code\game\objects\balls.dm"
 #include "modular_aeiou\code\game\objects\items\weapons\forms_heads.dm"


### PR DESCRIPTION
It compiled after the monkey thing was fixed.

:cl: EvilJackCarver
rscadd: You can now buy a crate of air rifles from Cargo, with a very slim chance of getting a Cuban Pete limited-edition model!
rscadd: Air rifle crate costs 25 credits and currently does not require clearance.
/:cl:

