### PR TITLE
HALF LIFE - FULL LIFE CONSEQUENCES I

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -676,8 +676,7 @@
 					message = "makes a very loud noise."
 					m_type = 2
 
-		if("snap", "snaps")
-			m_type = 2
+		if("snap", "snaps") /* AEIOU EDIT - Added feature for naughty spammers - HTG */
 			var/mob/living/carbon/human/H = src
 			var/obj/item/organ/external/L = H.get_organ("l_hand")
 			var/obj/item/organ/external/R = H.get_organ("r_hand")
@@ -688,12 +687,38 @@
 			if(R && (!(R.status & ORGAN_DESTROYED)) && (!(R.splinted)) && (!(R.status & ORGAN_BROKEN)))
 				right_hand_good = 1
 
-			if(!left_hand_good && !right_hand_good)
+			if(!left_hand_good && !right_hand_good) //This is all that is required to snap... You can snap in cuffs, right?
 				to_chat(usr, "You need at least one hand in good working order to snap your fingers.")
 				return
 
-			message = "snaps [T.his] fingers."
-			playsound(loc, 'sound/effects/fingersnap.ogg', 50, 1, -3)
+			var/safe = 99 //We have a 1% chance to break our fingers.
+			var/list/involved_parts = list(BP_L_HAND, BP_R_HAND)
+			for(var/organ_name in involved_parts)
+				var/obj/item/organ/external/E = get_organ(organ_name)
+				if(!E || E.is_stump() || E.splinted || (E.status & ORGAN_BROKEN))
+					involved_parts -= organ_name
+					safe -= 4 //Add 4% to the chance for each injured hand. (5% Chance to break our fingers in total.)
+
+			var/breaking = pick(involved_parts)
+			var/obj/item/organ/external/E = get_organ(breaking)
+
+			/* AEIOU EDIT - Added feature for naughty spammers - HTG */
+			if(prob(safe))
+				playsound(loc, 'sound/effects/fingersnap.ogg', 50, 1, -3)
+				custom_emote(1, "snaps [T.his] fingers.")
+			else
+				if(E.cannot_break)
+					src.Weaken(5)
+					E.droplimb(1,DROPLIMB_EDGE)
+					playsound(loc, 'sound/effects/snap.ogg', 50, 1)
+					custom_emote(1, "<span class='danger'>snaps [T.his] fingers right off!</span>") // I need ideas, dont let me forget! - HTG
+					log_and_message_admins("lost [T.his] [breaking] with *snap, ahahah.", src)
+				else
+					src.Weaken(5)
+					E.fracture()
+					playsound(loc, 'sound/effects/snap.ogg', 50, 1)
+					custom_emote(1, "<span class='danger'>breaks [T.his] fingers! That looked painful.</span>") // I need ideas, dont let me forget! - HTG
+					log_and_message_admins("broke [T.his] [breaking] with *snap, ahahah.", src)
 
 		if("swish")
 			src.animate_tail_once()

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -25,45 +25,45 @@
 		if ("nme")
 			nme()
 			return TRUE
-		if ("flip")
-			var/danger = 1 //Base 1% chance to break something.
+		if ("flip", "flips") /* AEIOU EDIT - Added feature for naughty spammers - HTG */
+
+			//Taurs are harder to flip (Sorry, but this is just un-needed code. - HTG)
+			/*if(istype(tail_style, /datum/sprite_accessory/tail/taur))
+				safe -= 1*/
+
+			var/safe = 99 //We have a 1% chance to break our leg or foot.
 			var/list/involved_parts = list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
 			for(var/organ_name in involved_parts)
 				var/obj/item/organ/external/E = get_organ(organ_name)
 				if(!E || E.is_stump() || E.splinted || (E.status & ORGAN_BROKEN))
 					involved_parts -= organ_name
-					danger += 5 //Add 5% to the chance for each problem limb
-
-			//Taurs are harder to flip
-			if(istype(tail_style, /datum/sprite_accessory/tail/taur))
-				danger += 1
+					safe -= 4 //Add 4% to the chance for each injured leg/foot. (5% Chance to break our leg/foot in total.)
 
 			//Check if they are physically capable
 			if(src.sleeping || src.resting || src.buckled || src.weakened || src.restrained() || involved_parts.len < 2)
 				src << "<span class='warning'>You can't *flip in your current state!</span>"
 				return 1
-			else
-				src.SpinAnimation(7,1)
-				message = "does a flip!"
-				m_type = 1
 
-				if(prob(danger))
-					spawn(10) //Stick the landing.
-						var/breaking = pick(involved_parts)
-						var/obj/item/organ/external/E = get_organ(breaking)
-						if(isSynthetic())
-							src.Weaken(5)
-							E.droplimb(1,DROPLIMB_EDGE)
-							message += " <span class='danger'>And loses a limb!</span>"
-							log_and_message_admins("lost their [breaking] with *flip, ahahah.", src)
-						else
-							src.Weaken(5)
-							if(E.cannot_break) //Prometheans go splat
-								E.droplimb(0,DROPLIMB_BLUNT)
-							else
-								E.fracture()
-							message += " <span class='danger'>And breaks something!</span>"
-							log_and_message_admins("broke their [breaking] with *flip, ahahah.", src)
+			var/breaking = pick(involved_parts)
+			var/obj/item/organ/external/E = get_organ(breaking)
+
+			/* AEIOU EDIT - Added feature for naughty spammers - HTG */
+			if(prob(safe))
+				src.SpinAnimation(7,1)
+				custom_emote(1, "does a flip!")
+			else
+				if(E.cannot_break)
+					src.Weaken(5)
+					E.droplimb(1,DROPLIMB_EDGE)
+					custom_emote(1, "<span class='danger'>hits the ground and [T.his] limb suddenly snaps off! </span>") // I need ideas, dont let me forget! - HTG
+					log_and_message_admins("lost [T.his] [breaking] with *flip, ahahah.", src)
+				else
+					src.Weaken(5)
+					E.fracture()
+					custom_emote(1, "<span class='danger'>hits the ground and [T.his] limb suddenly makes a sickening cracking noise!</span>") // I need ideas, dont let me forget! - HTG
+					log_and_message_admins("broke [T.his] [breaking] with *flip, ahahah.", src)
+
+			return 1
 
 	if (message)
 		custom_emote(m_type,message)

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/human/proc/handle_emote_vr(var/act,var/m_type=1,var/message = null)
 
+	var/datum/gender/T = gender_datums[get_visible_gender()] //We could go ahead and replace every single 'their' with this. - HTG
+
 	switch(act)
 		if ("vwag")
 			if(toggle_tail_vr(message = 1))


### PR DESCRIPTION
This is my next step up - its actually pretty complex and in the end I found myself getting rid of a lot of the code used by VORE Station. What I've done - in simple - Is added a system to snapping (I went ahead and replaced the flipping system, it doesn't really change anything other than the tweak of a value and trimming of un-needed code.) that will take a 1% value (or if you've somehow injured your hands, a 5% value) and will usually allow you to snap. Somehow if you hit that 1% (Or 5%) or are spamming like crazy, you'll break your hand (Or you'll simply lose it if you're a synth or a slime person.). Next you'll notice, if you compile the code, there is some lovely placeholder flavortext in there that ACTUALLY shows this time. 

![image](https://user-images.githubusercontent.com/9869250/43683908-3c2aca3c-985b-11e8-83b6-9ace388d6d06.png)

If you've played long enough, you'll notice that the flavor text for breaking a limb does not show - that is fixed.

![image](https://user-images.githubusercontent.com/9869250/43683912-43710126-985b-11e8-8925-f472e6e5783f.png)

Sorry for the messy patch notes, I'd like to address here that I plan to add a similar system to whistling and screaming that (rather than ruin the game for loyal players) makes it more immersive to yell your absolute loudest and faint from lack of breath.