### PR TITLE
Day 1 welderfuel fix fixes

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -166,11 +166,12 @@
 			// // // BEGIN AEIOU EDIT // // //
 			if(Proj.combustion || Proj.damage >= proj_min_dmg_for_explosion)		//if the bullet would ignite something or damage greater thn 20...
 				explode()		//boom baby
-			else if(prob(proj_impact_leak_chance))		//10% chance to make it leak
+			else if(prob(proj_impact_leak_chance) && !modded)		//10% chance to make it leak
 				modded = TRUE		//it will leak and can be easily fixed. Not necessarily unwrenched manually. 
 				leak_fuel(amount_per_transfer_from_this/10.0)
 				message_admins("Fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]) leaking fuel due to gunshot.")
 				log_game("Fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]) leaking fuel due to gunshot.")
+				visible_message("<span class='warning'>You hear a faint dripping noise coming from \the [src]...</span>")
 			// // // END AEIOU EDIT // // //
 
 


### PR DESCRIPTION
* Fixes a potential issue caused by a missing check. Welderfuel tanks will not be able to leak even more if it's already leaking if shot to the point of leakage.
* Adds a (FLW) jump button to admin log leak warning.
* Adds a feedback message for the user, if their bullet causes the welderfuel tank to leak.

![image](https://user-images.githubusercontent.com/1784490/43699837-f8dcdc96-9915-11e8-87a8-5c681b2fc912.png)

CLOSES #64
CONTINUATION OF #63 
