### PR TITLE
Frees the Daemon

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -295,7 +295,7 @@
 	msg += attempt_vr(src,"examine_pickup_size",args) //VOREStation Code
 	msg += attempt_vr(src,"examine_step_size",args) //VOREStation Code
 	msg += attempt_vr(src,"examine_nif",args) //VOREStation Code
-	msg += attempt_vr(src,"examine_tone",args) //VOREStation Code
+//	msg += attempt_vr(src,"examine_tone",args) //VOREStation Code	//AEIOU edit: the examine_tone() is commented out so this effectively calls a nonexistent proc
 
 	if(mSmallsize in mutations)
 		msg += "[T.He] [T.is] very short!<br>"


### PR DESCRIPTION
* Should fix errors caused by functionally nonexistant proc being called when examining mobs, which means that Chatter's DreamDaemon console log should be cleaned up a bit.