### PR TITLE
Fixes borg examine text

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,19 +1,23 @@
+// // // BEGIN AEIOU EDIT // // //
+// ..(user, infix = custom_infix) was causing runtiming because there's no infix in mob/living/examine()
+//this is moved down to the actual examine bits.
 /mob/living/silicon/robot/examine(mob/user)
 	var/custom_infix = ""
 	if(custom_name)
 		custom_infix = ", [modtype] [braintype]"
-	..(user, infix = custom_infix)
+	..(user)
 
 	var/msg = ""
 	
-	// // // BEGIN AEIOU EDIT // // //
 	// Prints borg name and icon to chat. Stolen from /code/modules/mob/living/carbon/human/examine.dm
 	msg += "<span class='info'>*---------*<br>This is "
 	if(icon)
 		msg += "\icon[icon] " //fucking BYOND: this should stop dreamseeker crashing if we -somehow- examine somebody before their icon is generated
 
 	msg += "<EM>[src.name]</EM>"
-	msg += "</span><br>"	//end the info span, and newline before we do the bruteloss.
+	if(custom_name)
+		msg += custom_infix
+	msg += ".<br>"	//newline before we do the damage texts. 
 	// // // END AEIOU EDIT // // //
 
 	
@@ -54,6 +58,7 @@
 	// VOREStation Edit: End
 
 	msg += "*---------*"
+	msg += "</span>"		//AEIOU Edit: Ends the spans above
 
 	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -5,6 +5,18 @@
 	..(user, infix = custom_infix)
 
 	var/msg = ""
+	
+	// // // BEGIN AEIOU EDIT // // //
+	// Prints borg name and icon to chat. Stolen from /code/modules/mob/living/carbon/human/examine.dm
+	msg += "<span class='info'>*---------*<br>This is "
+	if(icon)
+		msg += "\icon[icon] " //fucking BYOND: this should stop dreamseeker crashing if we -somehow- examine somebody before their icon is generated
+
+	msg += "<EM>[src.name]</EM>"
+	msg += "</span><br>"	//end the info span, and newline before we do the bruteloss.
+	// // // END AEIOU EDIT // // //
+
+	
 	msg += "<span class='warning'>"
 	if (src.getBruteLoss())
 		if (src.getBruteLoss() < 75)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,7 @@
 /mob/living/silicon/robot/examine(mob/user)
-	var/custom_infix = custom_name ? ", [modtype] [braintype]" : ""
+	var/custom_infix = ""
+	if(custom_name)
+		custom_infix = ", [modtype] [braintype]"
 	..(user, infix = custom_infix)
 
 	var/msg = ""
@@ -26,9 +28,12 @@
 
 	switch(src.stat)
 		if(CONSCIOUS)
-			if(!src.client)	msg += "It appears to be in stand-by mode.\n" //afk
-		if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
-		if(DEAD)			msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n"
+			if(!src.client)	
+				msg += "It appears to be in stand-by mode.\n" //afk
+		if(UNCONSCIOUS)		
+			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
+		if(DEAD)			
+			msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n"
 	msg += attempt_vr(src,"examine_bellies_borg",args) //VOREStation Edit
 
 	// VOREStation Edit: Start

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -58,7 +58,7 @@
 	// VOREStation Edit: End
 
 	msg += "*---------*"
-	msg += "</span>"		//AEIOU Edit: Ends the spans above
+	msg += "</span>"		//AEIOU Edit: Ends the info span above, where the borg name stuff is
 
 	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"
 


### PR DESCRIPTION
* Fixes a runtime caused by a proc argument existing in `/atom/proc/examine` but not in `mob/living/examine`
* Adds borg name to their examine text.
* General code upkeep in code/modules/mob/living/silicon/robot/examine.dm for ease of legibility.