### PR TITLE
Patch for a whitelist issue

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -287,6 +287,17 @@ var/global/datum/controller/occupations/job_master
 					if(!job.player_old_enough(player.client))
 						Debug("DO player not old enough, Player: [player], Job:[job.title]")
 						continue
+					
+					// // // BEGIN AEIOU EDIT // // //
+					/* 
+					 * Theoretically fixes an issue where a player could join as a whitelisted job if it was selected before 
+					 * the whitelist made them unable to select it. This only denies them the ability to spawn as the job, it
+					 * does not unset it in their preferences. ^Spitzer
+					 */
+					if(!is_job_whitelisted(player, job.title))
+						Debug("DO player not whitelisted for this job, Player: [player], Job: [job.title]")
+						continue
+					// // // END AEIOU EDIT // // //
 
 					// If the player wants that job on this level, then try give it to him.
 					if(player.client.prefs.GetJobDepartment(job, level) & job.flag)


### PR DESCRIPTION
* Theoretically fixes an issue where a player that had their preferences on high before a whitelist came into effect could still randomly get a whitelisted job.