### PR TITLE
End-of-round tweaks (POLL BEFORE COMMITTING)

### DIFF
--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -21,6 +21,9 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	var/datum/announcement/priority/emergency_shuttle_docked = new(0, new_sound = sound('sound/AI/shuttledock.ogg'))
 	var/datum/announcement/priority/emergency_shuttle_called = new(0, new_sound = sound('sound/AI/shuttlecalled.ogg'))
 	var/datum/announcement/priority/emergency_shuttle_recalled = new(0, new_sound = sound('sound/AI/shuttlerecalled.ogg'))
+	
+	// AEIOU added vars
+	var/shift_change_horn = TRUE		//Should we have a shift-change horn when the shuttle gets called?
 
 /datum/emergency_shuttle_controller/New()
 	escape_pods = list()
@@ -49,7 +52,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 		if (autopilot)
 			set_launch_countdown(SHUTTLE_LEAVETIME)	//get ready to return
 			var/estimated_time = round(estimate_launch_time()/60,1)
-
+			world.log << "Shuttle at station."
 			if (evac)
 				emergency_shuttle_docked.Announce(replacetext(replacetext(using_map.emergency_shuttle_docked_message, "%dock_name%", "[using_map.dock_name]"),  "%ETD%", "[estimated_time] minute\s"))
 			else
@@ -106,6 +109,14 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	priority_announcement.Announce(replacetext(replacetext(using_map.shuttle_called_message, "%dock_name%", "[using_map.dock_name]"),  "%ETA%", "[estimated_time] minute\s"))
 	atc.shift_ending()
 
+	// // // BEGIN AEIOU EDIT // // //
+	world.log << "Scheduled crew transfer has begun."		//let the guy in the console see it
+	if(shift_change_horn)
+		spawn(48)		//1 mile at speed of sound in air at 0C, 1 bar pressure = 4.8574... seconds. This assumes the colony is at 1 mile away, and the horn is originating from there.
+			world << sound('sound/items/AirHorn.ogg', repeat = 0, wait = 0, volume = 10, channel = 3)	//Shift change horn
+	// // // END AEIOU EDIT // // //
+
+	
 //recalls the shuttle
 /datum/emergency_shuttle_controller/proc/recall()
 	if (!can_recall()) return

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -52,7 +52,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 		if (autopilot)
 			set_launch_countdown(SHUTTLE_LEAVETIME)	//get ready to return
 			var/estimated_time = round(estimate_launch_time()/60,1)
-			world.log << "Shuttle at station."
+			world.log << "Shuttle has arrived at station."		//AEIOU edit
 			if (evac)
 				emergency_shuttle_docked.Announce(replacetext(replacetext(using_map.emergency_shuttle_docked_message, "%dock_name%", "[using_map.dock_name]"),  "%ETD%", "[estimated_time] minute\s"))
 			else

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -361,7 +361,7 @@ var/global/datum/controller/gameticker/ticker
 						time_left -= 1 MINUTES
 						sleep(600)
 					if(!delay_end)
-						to_chat(world, "<span class='notice'><b>Round ended. Rebooting world.</b></span>")
+						to_chat(world, "<span class='notice'><b>Round ended. Rebooting world.</b></span>")		//AEIOU edit
 						world.Reboot()
 					else
 						to_chat(world, "<span class='notice'><b>An admin has delayed the round end.</b></span>")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -361,6 +361,7 @@ var/global/datum/controller/gameticker/ticker
 						time_left -= 1 MINUTES
 						sleep(600)
 					if(!delay_end)
+						to_chat(world, "<span class='notice'><b>Round ended. Rebooting world.</b></span>")
 						world.Reboot()
 					else
 						to_chat(world, "<span class='notice'><b>An admin has delayed the round end.</b></span>")
@@ -382,6 +383,7 @@ var/global/datum/controller/gameticker/ticker
 		return 1
 
 /datum/controller/gameticker/proc/declare_completion()
+	world.log <<  "Round ended. Mode: [mode.name]."		//AEIOU edit: log to console that the round is over
 	world << "<br><br><br><H1>A round of [mode.name] has ended!</H1>"
 	for(var/mob/Player in player_list)
 		if(Player.mind && !isnewplayer(Player))


### PR DESCRIPTION
* Adds hostconsole feedback when a shift change starts, when the shuttle arrives at the station, and when the round ends properly.
* Adds a shift change horn to the station, as an extra bit of detail. It's on a variable and can be disabled.
* Adds a bit of feedback for the player when the server reboots for a new round.

Known issue: The horn may sound more than once if admin intervention causes the crew transfer shuttle to be called more than once. This issue should not come up during normal play, and as such no sanity checks for such an event have been added. 