### PR TITLE
Air rifle updates

### DIFF
--- a/modular_aeiou/code/modules/projectiles/guns/projectile/shotgun_aeiou.dm
+++ b/modular_aeiou/code/modules/projectiles/guns/projectile/shotgun_aeiou.dm
@@ -11,7 +11,9 @@
 	ammo_type = /obj/item/ammo_casing/caseless/a177bb
 	projectile_type = /obj/item/projectile/bullet/reusable/air_rifle_bb
 	action_sound = 'sound/weapons/autoguninsert.ogg'		//reasonably close to the sound the real one makes
-	
+	description_info = "This is a ballistic weapon.  To fire the weapon, ensure your intent is *not* set to 'help', have your gun mode set to 'fire', \
+	then click where you want to fire.  After firing, you will need to re-cock the gun, by clicking on the gun in your hand. To reload, load more BBs\
+	into the gun. Spent BBs that are not mangled can be reused."
 
 /obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/pump(mob/M as mob)
 	playsound(M, action_sound, 60, 1)
@@ -43,33 +45,33 @@
 	icon_state = "ryder-le"
 	var/nice_direction = "null"		//this is intended to be a string that says null
 
-/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le/examine(mob/user)
+/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le/examine(mob/living/user)
 	. = ..()
 	
 	nice_direction = "unset"		//debugging and sanity checks
-	//compass check
-	if(isCardinal(user.dir))
-		nice_direction = "unset_cardinal"		//debugging and sanity checks
-		switch(user.dir)
-			if(NORTH)
-				nice_direction = "north"
-			if(EAST)
-				nice_direction = "east"
-			if(SOUTH)
-				nice_direction = "south"
-			if(WEST)
-				nice_direction = "west"
-	
-	if(user.item_is_in_hands(src))
-		to_chat(user, "The compass says you are facing [nice_direction].")
-		else		//not on a cardinal direction
-			to_chat(user, "The compass needle isn't pointing to a single direction.")
-	else	//rifle not in hands
-		to_chat(user, "The compass is too small to read at this angle.")
 
-	//clock check
-	if(user.item_is_in_hands(src) || in_range(src, user))
-		to_chat(user, "The thing which tells time says it is currently [stationtime2text()].")
-	else
-		to_chat(user, "The digits on the thing which tells time are too small to read from here. You'll have to get closer if you want to read it.")
+	if(isliving(user))		//necessary to avoid runtiming
+		//compass check
+		if(user.item_is_in_hands(src))
+			if(isCardinal(user.dir))
+				nice_direction = "unset_cardinal"		//debugging and sanity checks
+				switch(user.dir)
+					if(NORTH)
+						nice_direction = "north"
+					if(EAST)
+						nice_direction = "east"
+					if(SOUTH)
+						nice_direction = "south"
+					if(WEST)
+						nice_direction = "west"
+				to_chat(user, "<span class='notice'>The compass says you are facing [nice_direction].</span>")
+			else		//not on a cardinal direction
+				to_chat(user, "<span class='notice'>The compass needle isn't pointing to a single direction.</span>")
+		else	//rifle not in hands
+			to_chat(user, "<span class='notice'>The compass is too small to read at this angle.</span>")
 
+		//clock check
+		if(user.item_is_in_hands(src) || in_range(src, user))
+			to_chat(user, "<span class='notice'>The thing which tells time says it is currently [stationtime2text()].</span>")
+		else
+			to_chat(user, "<span class='notice'>The clock's digits are too small to read from here. You'll have to get closer if you want to read it.</span>")

--- a/modular_aeiou/code/modules/projectiles/guns/projectile/shotgun_aeiou.dm
+++ b/modular_aeiou/code/modules/projectiles/guns/projectile/shotgun_aeiou.dm
@@ -12,6 +12,7 @@
 	projectile_type = /obj/item/projectile/bullet/reusable/air_rifle_bb
 	action_sound = 'sound/weapons/autoguninsert.ogg'		//reasonably close to the sound the real one makes
 	
+
 /obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/pump(mob/M as mob)
 	playsound(M, action_sound, 60, 1)
 
@@ -40,25 +41,35 @@
 	name = "\improper Cuban Pete limited-edition air rifle"
 	desc = "A Cuban Pete carbine-action, sixty-shot Range Master air-rifle with a fake compass on the stock and a carving of this thing which tells time."
 	icon_state = "ryder-le"
-
-	var/fake_compass_reading = "null"			//i am aware this is a string that says null
-	var/fake_time = "null"
-
-
-/obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le/New()		//set the time that the carving of the clock shows
-	. = ..()
-	fake_compass_reading = pick("north","northeast","east","southeast","south","southwest","west","northwest")
-
-	var/fake_hour = rand(1,12)
-	var/fake_minute = rand(0,11)
-	fake_minute *= 5		//turn the clock position into a minute value, round to five
-
-	fake_time = "[fake_hour]:[fake_minute]"
-
+	var/nice_direction = "null"		//this is intended to be a string that says null
 
 /obj/item/weapon/gun/projectile/shotgun/pump/air_rifle/le/examine(mob/user)
 	. = ..()
-	//to_chat(user, "The fake compass says you are facing [fake_compass_reading].")
-	to_chat(user, "The fake compass says you are facing north.")
-	to_chat(user, "The carving of that thing which tells time says it is currently [fake_time].")
-	//It says twice that the compass is fake and the clock is a carving, so if the end user trusts them, it's on the user.
+	
+	nice_direction = "unset"		//debugging and sanity checks
+	//compass check
+	if(isCardinal(user.dir))
+		nice_direction = "unset_cardinal"		//debugging and sanity checks
+		switch(user.dir)
+			if(NORTH)
+				nice_direction = "north"
+			if(EAST)
+				nice_direction = "east"
+			if(SOUTH)
+				nice_direction = "south"
+			if(WEST)
+				nice_direction = "west"
+	
+	if(user.item_is_in_hands(src))
+		to_chat(user, "The compass says you are facing [nice_direction].")
+		else		//not on a cardinal direction
+			to_chat(user, "The compass needle isn't pointing to a single direction.")
+	else	//rifle not in hands
+		to_chat(user, "The compass is too small to read at this angle.")
+
+	//clock check
+	if(user.item_is_in_hands(src) || in_range(src, user))
+		to_chat(user, "The thing which tells time says it is currently [stationtime2text()].")
+	else
+		to_chat(user, "The digits on the thing which tells time are too small to read from here. You'll have to get closer if you want to read it.")
+

--- a/modular_aeiou/code/modules/projectiles/projectile/reusable.dm
+++ b/modular_aeiou/code/modules/projectiles/projectile/reusable.dm
@@ -40,7 +40,7 @@
 	icon_state = "bb-steel"
 	damage = 3
 	agony = 15		//they sting to get hit by, even at post-ricochet velocities
-	SA_bonus_damage = 37		//40 damage against simplemobs
+	SA_bonus_damage = 32		//35 damage against simplemobs
 	SA_vulnerability = SA_ANIMAL
 	fire_sound = 'sound/weapons/gunshot_air_rifle.ogg'
 	sharp = 0
@@ -115,10 +115,20 @@
 							"<span class='danger'>\The [src] hits \the [target] in the eye!</span>",
 							"<span class='userdanger'>\The [src] hits you in the eye!</span>"
 							)
+							
 				message_already_sent = TRUE
 				agony = 75
 				if(target.can_feel_pain())
 					target.emote("scream")
+				
+				target.Blind(5)		//blind them for a few seconds
+				target.eye_blurry = 5
+				
+				if(!(target.disabilities & NEARSIGHTED))	//a check to see if they're already nearsighted, so we don't accidentally cure their vision
+					target.disabilities |= NEARSIGHTED
+					spawn(300)		//30 seconds
+						target.disabilities &= ~NEARSIGHTED
+	
 	if(!message_already_sent)
 		if(silenced)
 			to_chat(target_mob, "<span class='danger'>You've been hit in the [parse_zone(def_zone)] by \the [src]!</span>")
@@ -143,15 +153,16 @@
 		if(prob(drop_chance))		//if you win the bullet lottery, have a new bullet
 			new ammo_type(src.loc)
 		else
-			new /obj/item/trash/mangled_bb(src.loc)		//defined below
+			new /obj/item/ammo_casing/spent/mangled_bb(src.loc)		//defined below
 		dropped = TRUE
 
 //Mangled, non-reusable BB. Technically not a bullet, but here for ease of organization.
-/obj/item/trash/mangled_bb		
+/obj/item/ammo_casing/spent/mangled_bb		
 	name = "mangled BB"
-	w_class = ITEMSIZE_TINY
-	desc = "This is rubbish. No way this'll fit in your air rifle."
-	description_info = "This is useless."
+	caliber = "unusable"
+	desc = "A dented piece of zinc-coated steel airgun shot."
+	description_info = "This won't reload into your air rifle, but it can be recycled at an autolathe for a tiny amount of metal."
 	icon = 'modular_aeiou/icons/obj/projectile_aeiou.dmi'
 	icon_state = "bb-steel"
 	sharp = FALSE
+	matter = list(DEFAULT_WALL_MATERIAL = 10)


### PR DESCRIPTION
* Mangled BBs can now be recycled at an autolathe.
* Air rifles do more "damage" when hitting a target in the eye: The eye damage variable is unchanged, but it will blind the target and, if they're not already nearsighted, stunt their vision for a short time.
* Fixed description text, now notes you can reuse BBs
* Nerfs simpleanimal damage to 35
* Fixes Limited Edition examine text. The clock and compass now function properly.

CLOSES #80 AS FIXED