### PR TITLE
Tweaks to end-of-shift horn

### DIFF
--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -24,6 +24,8 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	
 	// AEIOU added vars
 	var/shift_change_horn = TRUE		//Should we have a shift-change horn when the shuttle gets called?
+	var/shift_change_horn_file = 'sound/items/AirHorn.ogg'
+	var/shift_change_horn_volume = 10
 
 /datum/emergency_shuttle_controller/New()
 	escape_pods = list()
@@ -113,7 +115,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	world.log << "Scheduled crew transfer has begun."		//let the guy in the console see it
 	if(shift_change_horn)
 		spawn(48)		//1 mile at speed of sound in air at 0C, 1 bar pressure = 4.8574... seconds. This assumes the colony is at 1 mile away, and the horn is originating from there.
-			world << sound('sound/items/AirHorn.ogg', repeat = 0, wait = 0, volume = 10, channel = 3)	//Shift change horn
+			world << sound(shift_change_horn_file, repeat = 0, wait = 0, volume = shift_change_horn_volume, channel = 3)	//Shift change horn
 	// // // END AEIOU EDIT // // //
 
 	

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -115,10 +115,14 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	world.log << "Scheduled crew transfer has begun."		//let the guy in the console see it
 	if(shift_change_horn)
 		spawn(48)		//1 mile at speed of sound in air at 0C, 1 bar pressure = 4.8574... seconds. This assumes the colony is at 1 mile away, and the horn is originating from there.
-			world << sound(shift_change_horn_file, repeat = 0, wait = 0, volume = shift_change_horn_volume, channel = 3)	//Shift change horn
-	// // // END AEIOU EDIT // // //
-
+			blow_horn()
 	
+/datum/emergency_shuttle_controller/proc/blow_horn()
+	world << sound(shift_change_horn_file, repeat = 0, wait = 0, volume = shift_change_horn_volume, channel = 3)
+	shift_change_horn = FALSE
+	// // // END AEIOU EDIT // // //
+		
+		
 //recalls the shuttle
 /datum/emergency_shuttle_controller/proc/recall()
 	if (!can_recall()) return


### PR DESCRIPTION
* End-of-shift horn file and volume are now variables for easier adminbus.
* Shift horn is now turned into a proc, so admins can blow it whenever they want, for further adminbus.
* The end-of-shift horn will now only blow once without admin involvement; if the horn blows it disables it for the rest of the round.